### PR TITLE
Document custom form elements for study configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+Docs Tech Stack
+- Docusaurus
+- Vite
+
+Purpose
+This docs repo supports the ReVISit project. The docs are for users of our software, study designers. These study designers should be assumed to have some basic development knowledge (e.g. they know what JSON is and might have built a few websites, but they're not react experts).
+
+The ReVISit project aims to create a robust platform for conducting and analyzing user studies focused on interactive data visualization tools. By leveraging modern web technologies and state management solutions, ReVISit provides researchers with the necessary tools to design, deploy, and evaluate visualization interfaces effectively.
+
+The goal is to expand the scope of user studies to beyond the visualization community, making it easier for researchers from various fields to conduct studies on interactive data visualizations. This means we need state management that can handle complex interactions and data flows, as well as a user-friendly interface for both study designers and participants.
+
+ReVISit Tech Stack
+- Yarn
+- React 18
+- TypeScript
+- Vite
+- Mantine UI
+- Firebase or Supabase as storage and database backends (.env selects the engine)
+
+Verbiage
+- "Study Designer": The individual who creates and configures the user study.
+- "Participant": The user who takes part in the study.
+- "Analyst": The individual who reviews and analyzes the data collected from the study, both in the platform and externally.
+- "Study Config": The configuration file that defines the parameters and settings of a user study.
+
+Study Configs
+The study configurations are defined in JSON files with schemas. These configs specify various aspects of the study, including the visualization tools to be used, the tasks participants need to complete, and the data sources involved. You can find the full definition of the study config typescript at https://raw.githubusercontent.com/revisit-studies/study/dev/src/parser/parser.ts. When adding new docs, always ready the current version of the schema and assume that you should read from the `dev` branch (replace dev in the string above if you're asked to look at a different branch).
+
+How you should interact with this docs codebase
+You should read docs related to features that you're adding Fore example, if we're adding anew component, read the docs for the other component types. You can run git commands but don't run them unless asked to. Don't interact with GitHub issues or pull requests directly. You should only ever write user facing documentation, we don't host any development/architectural documents in this repo.
+
+Typedoc
+Typedoc is built from the app for every release and included as reference material so you don't need to add that to this repo. Assume it will be handled, but state your assumption.

--- a/docs/designing-studies/custom-form-elements.md
+++ b/docs/designing-studies/custom-form-elements.md
@@ -1,0 +1,117 @@
+# Custom Form Elements
+
+Sometimes, the [form elements](./forms.md) ReVISit provides are not sufficient for your needs. In this case, you can create your own custom form elements. Your custom form elements can be coded in React and can use any React libraries you want. You can then include these custom form elements in your study config and they will be rendered in the study just like the built-in form elements.
+
+This page will walk you through how to create and use custom form elements in your ReVISit study, and show you how to provide custom validation logic for your custom form elements.
+
+## Creating Custom Form Elements
+
+To create a custom form element, you need to define a React component that follows the structure defined by the `CustomResponseParams` type. This component receives the current response value, metadata about the response itself, optional custom parameters from the study config, validation state, and a `field` helper for updating and blurring the value. You can then use this component in your study configuration to collect responses from participants. Here's a basic example of a custom form element that collects a color input from participants:
+
+```tsx title="ColorPicker.tsx"
+import { CustomResponseParams } from '../../../store/types';
+
+type ColorPickerValue = string;
+
+export default function ColorPicker({
+  response,
+  value,
+  error,
+  disabled,
+  field,
+}: CustomResponseParams<Record<string, unknown>, ColorPickerValue>) {
+  const inputProps = field.getInputProps();
+
+  return (
+    <>
+      <p>{response.prompt}</p>
+      <input
+        type="color"
+        {...inputProps}
+        value={typeof value === 'string' ? value : '#000000'}
+        disabled={disabled}
+        onChange={(event) => field.setValue(event.currentTarget.value)}
+        onBlur={() => field.onBlur()}
+      />
+      {error && <p>{error}</p>}
+    </>
+  );
+}
+```
+
+In this example, the `ColorPicker` component renders an HTML color input. The `getInputProps` function is useful for wiring a native input, while `setValue` updates the stored answer and `onBlur` marks the field as interacted with. For more custom interfaces, you can call `setValue` and `onBlur` directly without relying much on `getInputProps`.
+
+## Using Custom Form Elements in Your Study Config
+
+To use your custom form element in your study config, you need to define a response with `type` set to `custom` and provide the path to your custom form element component. Custom responses live inside a component's `response` array, just like built-in response types. Here's how you can include the `ColorPicker` custom form element in your study config:
+
+```json
+{
+  "type": "questionnaire",
+  "response": [
+    {
+      "id": "favoriteColor",
+      "prompt": "What is your favorite color?",
+      "location": "belowStimulus",
+      "type": "custom",
+      "path": "my-study/assets/ColorPicker.tsx",
+      "default": "#ff0000"
+    }
+  ]
+}
+```
+
+::note[Note]
+The path here is relative to the `src/public` directory of the ReVISit app, not the `public` directory used for most other study assets. You can place your custom form element component anywhere under `src/public`. We recommend that you follow the same folder structure that we suggest in the [react stimulus docs](./react-stimulus.md) for your custom form elements.
+:::
+
+## Custom Validation Logic for Custom Form Elements
+
+Custom validation logic can be added to your custom form elements by defining a validation function that checks the response value and returns an error message if the value is invalid. The validation controls whether the participant can submit their response or not. The `validate` function receives the current value, the full set of response values for the component, and the current response config, so it can validate against sibling answers or `response.parameters`. Here's an example of how you can add custom validation logic to the `ColorPicker` component:
+
+```tsx title="ColorPickerWithValidation.tsx"
+import { CustomResponseParams, CustomResponseValidate } from '../../../store/types';
+
+type ColorPickerValue = string;
+
+export default function ColorPicker({
+  response,
+  value,
+  error,
+  disabled,
+  field,
+}: CustomResponseParams<Record<string, unknown>, ColorPickerValue>) {
+  const inputProps = field.getInputProps();
+
+  return (
+    <>
+      <p>{response.prompt}</p>
+      <input
+        type="color"
+        {...inputProps}
+        value={typeof value === 'string' ? value : '#000000'}
+        disabled={disabled}
+        onChange={(event) => field.setValue(event.currentTarget.value)}
+        onBlur={() => field.onBlur()}
+      />
+      {error && <p>{error}</p>}
+    </>
+  );
+}
+
+export const validate: CustomResponseValidate<ColorPickerValue> = (value, _values, response) => {
+  if (typeof value !== 'string' || !value) {
+    return `Please select a color for "${response.prompt}".`;
+  }
+
+  return null;
+};
+```
+
+In this example, we supplied a `validate` function that checks if a color has been selected. If no color is selected, it returns an error message prompting the participant to select a color. If a color is selected, it returns `null`, indicating that the response is valid. The function must be called `validate` and must be exported from the same file as the custom form element component.
+
+When you include this custom form element in your study config, the validation logic will be automatically applied, and participants will not be able to submit their response until they have selected a color.
+
+## Provenance tracking for custom form elements
+
+Since custom form elements are hooked into the same response system as built-in form elements, they will automatically have provenance tracking enabled. For proper rehydration of the response values, make sure that your custom form element component updates values through `field.setValue(...)` and marks interaction with `field.onBlur()`. This ensures that the response values are properly tracked and can be analyzed.

--- a/docs/designing-studies/custom-form-elements.md
+++ b/docs/designing-studies/custom-form-elements.md
@@ -6,7 +6,7 @@ This page will walk you through how to create and use custom form elements in yo
 
 ## Creating Custom Form Elements
 
-To create a custom form element, you need to define a React component that follows the structure defined by the `CustomResponseParams` type. This component receives the current response value, metadata about the response itself, optional custom parameters from the study config, validation state, and a `field` helper for updating and blurring the value. You can then use this component in your study configuration to collect responses from participants. Here's a basic example of a custom form element that collects a color input from participants:
+To create a custom form element, you need to define a React component that follows the structure defined by the `CustomResponseParams` type. This component receives the current response value, metadata about the response itself, optional custom parameters from the study config, the current validation error message if one exists, and a `field` helper for updating and blurring the value. You can then use this component in your study configuration to collect responses from participants. Here's a basic example of a custom form element that collects a color input from participants:
 
 ```tsx title="ColorPicker.tsx"
 import { CustomResponseParams } from '../../../store/types';
@@ -65,6 +65,10 @@ To use your custom form element in your study config, you need to define a respo
 The path here is relative to the `src/public` directory of the ReVISit app, not the `public` directory used for most other study assets. You can place your custom form element component anywhere under `src/public`. We recommend that you follow the same folder structure that we suggest in the [react stimulus docs](./react-stimulus.md) for your custom form elements.
 :::
 
+::note[JSON-serializable values]
+Custom response values must be JSON-serializable. This applies both to the values you store through `field.setValue(...)` and to any `default` value you define in the study config. Strings, numbers, booleans, `null`, arrays, and plain objects are supported.
+:::
+
 ## Custom Validation Logic for Custom Form Elements
 
 Custom validation logic can be added to your custom form elements by defining a validation function that checks the response value and returns an error message if the value is invalid. The validation controls whether the participant can submit their response or not. The `validate` function receives the current value, the full set of response values for the component, and the current response config, so it can validate against sibling answers or `response.parameters`. Here's an example of how you can add custom validation logic to the `ColorPicker` component:
@@ -114,4 +118,4 @@ When you include this custom form element in your study config, the validation l
 
 ## Provenance tracking for custom form elements
 
-Since custom form elements are hooked into the same response system as built-in form elements, they will automatically have provenance tracking enabled. For proper rehydration of the response values, make sure that your custom form element component updates values through `field.setValue(...)` and marks interaction with `field.onBlur()`. This ensures that the response values are properly tracked and can be analyzed.
+Since custom form elements are hooked into the same response system as built-in form elements, their answers participate in the standard saving and provenance flow. To keep the stored answer in sync, update values through `field.setValue(...)`. Call `field.onBlur()` when the user finishes interacting with the element so validation and touched-state behavior work as expected.


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This PR adds user-facing documentation for custom form elements in ReVISit. The new page explains how Study Designers can build a React-based custom response component, include it in a study config with type: "custom", and pass values through the provided field helpers so responses behave like built-in form elements.

It also documents how to add custom validation by exporting a validate function from the same component file, and clarifies provenance tracking expectations for rehydration and analysis. Typedoc reference material is assumed to continue being generated from the app during release rather than maintained in this docs repo.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
No