### PR TITLE
docs: move action name warning above screenshot

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,11 +50,11 @@ Navigate to the [template repository](https://github.com/revisit-studies/templat
 
 ![Use this template button](./img/template-repo.png)
 
-![Create a new repository from the template](./img/create-new-repo.png)
-
 :::info
 You can choose a name for the repository to suit your needs, but if you choose anything other than `study`, you also need to adjust the `VITE_BASE_PATH` in your [`.env`](https://github.com/revisit-studies/study/blob/main/.env) file to reflect that change.
 :::
+
+![Create a new repository from the template](./img/create-new-repo.png)
 
 You can then clone this new repository to your local machine and start making changes to it and share it with collaborators as desired.
 


### PR DESCRIPTION
### Does this PR close any open issues?
No.

### Give a longer description of what this PR addresses and why it's needed
This PR makes a small documentation improvement in the [Getting Started](https://revisit.dev/docs/getting-started/installation/) guide. 

Previously, the warning about choosing the repo name appeared after the action screenshot. This made it easy to miss and could lead users (as happened to me) to pick a different name for arbitrary reasons. This PR moves the warning above the screenshot so users see it before naming the action.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before: 
<img width="975" height="763" alt="image" src="https://github.com/user-attachments/assets/e52db5b2-e336-422d-ba17-8f9471deaf34" />

After: 
<img width="980" height="755" alt="image" src="https://github.com/user-attachments/assets/9c1931b4-196f-4cbb-91fe-352b683348bf" />


### Are there any additional TODOs before this PR is ready to go?
No.