### PR TITLE
Document managed Trrack provenance migration

### DIFF
--- a/docs/designing-studies/html-stimulus.md
+++ b/docs/designing-studies/html-stimulus.md
@@ -85,6 +85,30 @@ One of the interesting pieces of the above code is that this HTML document inter
 
 Furthermore, you’ll see that we have also created an `onClick` function and attached it to each of the bars in the bar graph. This click function uses the `Revisit.postAnswers` method to send information back to reVISit.
 
+### Adding provenance tracking
+
+For a website or iframe stimulus that uses Trrack, create the instance with `Revisit.createTrrack`:
+
+```js
+const trrack = Revisit.createTrrack({
+  initializeTrrack,
+  registry,
+  initialState,
+});
+```
+
+This managed API automatically captures the initial state and every apply, undo, redo, or other traversal. It also removes its subscription when the iframe page is discarded. Continue to use `Revisit.postAnswers` for answers.
+
+During replay, render the state reVISit sends to the iframe:
+
+```js
+Revisit.onProvenanceReceive((provenanceState) => {
+  renderState(provenanceState);
+});
+```
+
+Calling `Revisit.postProvenance(trrack.graph.backend)` manually is deprecated, but remains backward-compatible for existing and historical studies. See [Provenance Tracking](provenance-tracking.md) for a complete example and migration guidance.
+
 Now that we have this HTML document in our study directory, we are ready to adjust our `config.json` file to account for these new components.
 
 In your `config.json` document, create new key called `baseComponents` as a sibling to the keys `uiConfig`, `components`, `sequence`, etc. In this newly created key, paste the code below:
@@ -146,6 +170,7 @@ import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLink
   referenceLinks={[
     {name: "D3.js", url: "https://d3js.org/"},
     {name: "WebsiteComponent", url: "../../typedoc/interfaces/WebsiteComponent"},
-    {name: "BaseComponents", url: "../../typedoc/type-aliases/BaseComponents/"}
+    {name: "BaseComponents", url: "../../typedoc/type-aliases/BaseComponents/"},
+    {name: "Provenance Tracking", url: "../provenance-tracking"}
   ]}
 />

--- a/docs/designing-studies/provenance-tracking.md
+++ b/docs/designing-studies/provenance-tracking.md
@@ -1,101 +1,215 @@
 # Provenance Tracking
 
-ReVISit has integrated provenance tracking with Trrack, a state-based provenance tracking library maintained by the same team that maintains reVISit. For more detailed information on Trrack and its API, visit the [Trrack documentation](https://apps.vdl.sci.utah.edu/trrack).
+ReVISit integrates with [Trrack](https://apps.vdl.sci.utah.edu/trrack), a state-based provenance tracking library maintained by the reVISit team. Use reVISit's managed Trrack APIs for new studies:
 
-## Integrating into a React and HTML component
+- React stimuli: `useRevisitTrrack`
+- Website or iframe stimuli: `Revisit.createTrrack`
 
-Building off the [Stroop color experiment](react-stimulus.md#example-2-stroop-color-experiment-with-reactive-response) from the React stimulus tutorial, we add provenance tracking to record each keystroke and enable replay.
+Both APIs create a Trrack instance, subscribe before returning control to the stimulus, and immediately capture the initial state. They then capture every current-node transition, including `apply`, `undo`, `redo`, direct traversal, and branches created after undo. The recorded traversal history lets participant replay follow the interaction path in chronological order instead of inferring it from graph creation time.
 
-### 1. Define state and create Trrack with `useMemo`
+The managed subscription is also cleaned up with the stimulus lifecycle: React unsubscribes when the stimulus unmounts, and website stimuli unsubscribe when the page is discarded.
 
-Because Trrack is state-based, you must define a state for your tracked application. For the Stroop text input:
+## React stimuli: `useRevisitTrrack`
 
-```ts title="src/public/demo-react-trrack/assets/DemoReactTrrack.tsx"
+Building on the [Stroop color experiment](react-stimulus.md#example-2-stroop-color-experiment-with-reactive-response), the following example records each response change and supports replay.
+
+### 1. Define the tracked state and actions
+
+Create the registry and actions once. The managed hook creates the Trrack instance, so do not call `initializeTrrack` yourself.
+
+```tsx title="src/public/demo-react-trrack/assets/DemoReactTrrack.tsx"
+import { useMemo } from 'react';
+import { Registry } from '@trrack/core';
+import { useRevisitTrrack } from '../../../store/hooks/useRevisitTrrack';
+
 interface StroopState {
   response: string;
 }
-```
 
-Create the Trrack registry, action, and instance **once** using `useMemo` (empty deps). This ensures the instance is stable across renders:
+const { actions, registry } = useMemo(() => {
+  const registry = Registry.create();
+  const setResponse = registry.register(
+    'setResponse',
+    (state, response: string) => {
+      state.response = response;
+      return state;
+    },
+  );
 
-```ts title="src/public/demo-react-trrack/assets/DemoReactTrrack.tsx"
-const { actions, trrack } = useMemo(() => {
-  const reg = Registry.create();
-  const setResponseAction = reg.register('setResponse', (state, nextResponse: string) => {
-    state.response = nextResponse;
-    return state;
-  });
-  const trrackInst = initializeTrrack({
-    registry: reg,
-    initialState: { response: '' },
-  });
-  return {
-    actions: { setResponseAction },
-    trrack: trrackInst,
-  };
+  return { actions: { setResponse }, registry };
 }, []);
 ```
 
-### 2. Call the action and pass `provenanceGraph` to `setAnswer`
+### 2. Create the managed Trrack instance
 
-When the user types, call the Trrack action and include `provenanceGraph` in `setAnswer` so reVISit stores the provenance. Use a `useCallback` to keep the handler stable:
+Pass the normal Trrack configuration to `useRevisitTrrack`. The hook must run inside a React stimulus rendered by reVISit.
 
-```ts title="src/public/demo-react-trrack/assets/DemoReactTrrack.tsx"
-const updateAnswer = useCallback((value: string) => {
-  setResponseText(value);
-  trrack.apply('Set response', actions.setResponseAction(value));
-  setAnswer({
-    status: value.trim().length > 0,
-    provenanceGraph: trrack.graph.backend,
-    answers: { stroopAnswer: value },
-  });
-}, [actions, setAnswer, trrack]);
-
-```
-
-### 3. Sync from `provenanceState` for replay
-
-During replay, reVISit passes `provenanceState` with the restored state. Sync it to your textbox so the input updates visibly when the user seeks through the timeline:
-
-```ts title="src/public/demo-react-trrack/assets/DemoReactTrrack.tsx"
-  useEffect(() => {
-    if (provenanceState) {
-      setResponseText(provenanceState.response);
-    }
-  }, [provenanceState]);
-```
-
-### Full component example
-
-For the complete Stroop component with provenance tracking, see [DemoReactTrrack.tsx](https://github.com/revisit-studies/study/blob/main/src/public/demo-react-trrack/assets/DemoReactTrrack.tsx).
-
-For a basic HTML + D3 example, see our [Dots example](https://github.com/revisit-studies/study/blob/main/public/demo-html-trrack/assets/dots-count.html). Creating a Trrack instance and actions works the same as above, just without the React hooks.
-
-## Using Trrack for undo/redo
-
-The above example shows the basic use case for Trrack if you just want to store provenance and enable replay. With a little more effort, Trrack can also give your stimulus undo/redo and full study rehydration.
-
-For this, use Trrack as your central storage instead of React state. Where you would normally call `setState`, call the Trrack action instead:
-
-```ts
-trrack.apply('Set response', setResponseAction(value));
-```
-
-To update the frontend when the current node changes (e.g., when `undo` or `redo` are called), add an observer:
-
-```ts
-trrack.currentChange(() => {
-  const response = trrack.getState().response;
-  setResponseText(response);
+```tsx
+const trrack = useRevisitTrrack({
+  registry,
+  initialState: { response: '' },
 });
 ```
 
-Add undo/redo via buttons or keybinds:
+The initial state is reported automatically. Calling any Trrack traversal method reports the updated graph and traversal event automatically:
 
-```ts
+```tsx
+trrack.apply('Set response', actions.setResponse(value));
 trrack.undo();
 trrack.redo();
+trrack.to(nodeId);
 ```
+
+Continue to use `setAnswer` for participant answers, but do not pass the provenance graph:
+
+```tsx
+const updateAnswer = (value: string) => {
+  trrack.apply('Set response', actions.setResponse(value));
+  setAnswer({
+    status: value.trim().length > 0,
+    answers: { stroopAnswer: value },
+  });
+};
+```
+
+### 3. Hydrate the visible stimulus during replay
+
+During participant replay, reVISit passes the state of the selected provenance node through `provenanceState`. Render from that state so the stimulus follows the replay timeline:
+
+```tsx
+useEffect(() => {
+  if (provenanceState) {
+    setResponseText(provenanceState.response);
+  }
+}, [provenanceState]);
+```
+
+`useRevisitTrrack` manages capture; `provenanceState` manages replay hydration. Do not call `apply` from this hydration effect, because replaying a historical state should not create a new participant action.
+
+For the complete example, see [DemoReactTrrack.tsx](https://github.com/revisit-studies/study/blob/dev/src/public/demo-react-trrack/assets/DemoReactTrrack.tsx).
+
+## Website and iframe stimuli: `Revisit.createTrrack`
+
+Include `revisit-communicate.js`, import Trrack's `initializeTrrack`, and pass that function with the normal Trrack options to `Revisit.createTrrack`:
+
+```html
+<script src="../../revisitUtilities/revisit-communicate.js"></script>
+<script type="module">
+  import { Registry, initializeTrrack } from 'https://cdn.jsdelivr.net/npm/@trrack/core@1.3.0/+esm';
+
+  const registry = Registry.create();
+  const setCount = registry.register('set-count', (state, count) => {
+    state.count = count;
+  });
+
+  const trrack = Revisit.createTrrack({
+    initializeTrrack,
+    registry,
+    initialState: { count: 0 },
+  });
+
+  addButton.onclick = () => {
+    trrack.apply('Increment', setCount(trrack.getState().count + 1));
+  };
+  undoButton.onclick = () => trrack.undo();
+  redoButton.onclick = () => trrack.redo();
+</script>
+```
+
+`Revisit.createTrrack` returns the normal Trrack instance. As with the React hook, it automatically reports the initial state and every apply, undo, redo, and other traversal.
+
+For replay hydration, register `Revisit.onProvenanceReceive` and render the received state. The parent resends the current state after the iframe reports that its window is ready, so the handler also works for slower-loading website stimuli.
+
+```js
+Revisit.onProvenanceReceive((provenanceState) => {
+  if (typeof provenanceState?.count === 'number') {
+    renderCount(provenanceState.count);
+  }
+});
+```
+
+For complete website examples, see the [HTML Dots example](https://github.com/revisit-studies/study/blob/dev/public/demo-html-trrack/assets/dots-count.html) and [Svelte Dots example](https://github.com/revisit-studies/study/blob/dev/public/demo-svelte-trrack/assets/dots-count.html).
+
+## API reference
+
+### `useRevisitTrrack(options)`
+
+| Item | Description |
+| --- | --- |
+| Availability | React stimuli rendered by reVISit |
+| Argument | Standard Trrack `ConfigureTrrackOptions`, including `registry` and `initialState` |
+| Returns | A standard Trrack instance |
+| Capture | Initial state and all current-node changes, including apply, undo, redo, and arbitrary traversal |
+| Cleanup | Unsubscribes automatically when the stimulus unmounts |
+| Hydration | Render the `provenanceState` stimulus prop during replay |
+
+### `Revisit.createTrrack({ initializeTrrack, ...options })`
+
+| Item | Description |
+| --- | --- |
+| Availability | Website and iframe stimuli that load `revisit-communicate.js` |
+| Arguments | The imported Trrack `initializeTrrack` function plus standard Trrack configuration options |
+| Returns | A standard Trrack instance |
+| Capture | Initial state and all current-node changes, including apply, undo, redo, and arbitrary traversal |
+| Cleanup | Unsubscribes automatically when the iframe page is discarded |
+| Hydration | Render state received by `Revisit.onProvenanceReceive` during replay |
+
+## Migrating existing studies
+
+### React: remove manual graph reporting
+
+The old pattern created Trrack directly and attached the graph to an answer update:
+
+```tsx title="Deprecated manual pattern"
+const trrack = initializeTrrack({ registry, initialState });
+
+trrack.apply('Set response', actions.setResponse(value));
+setAnswer({
+  status: true,
+  answers: { stroopAnswer: value },
+  provenanceGraph: trrack.graph.backend,
+});
+```
+
+Replace it with the managed hook and keep answer reporting separate:
+
+```tsx title="Managed pattern"
+const trrack = useRevisitTrrack({ registry, initialState });
+
+trrack.apply('Set response', actions.setResponse(value));
+setAnswer({
+  status: true,
+  answers: { stroopAnswer: value },
+});
+```
+
+### Website: replace `Revisit.postProvenance`
+
+The old pattern required every code path to publish the graph manually:
+
+```js title="Deprecated manual pattern"
+const trrack = initializeTrrack({ registry, initialState });
+
+trrack.currentChange(() => {
+  Revisit.postProvenance(trrack.graph.backend);
+});
+```
+
+Replace it with `Revisit.createTrrack` and remove the manual provenance callback:
+
+```js title="Managed pattern"
+const trrack = Revisit.createTrrack({
+  initializeTrrack,
+  registry,
+  initialState,
+});
+```
+
+:::warning Deprecated compatibility paths
+Passing `provenanceGraph` to `setAnswer` and calling `Revisit.postProvenance` are deprecated. They remain backward-compatible so existing and historical studies continue to record and load, but new studies should use the managed APIs.
+
+Historical provenance that contains only a graph and no traversal events also remains replayable through the legacy graph-only fallback. That fallback follows graph creation order and cannot accurately reproduce undo, redo, or arbitrary traversal, so graph-only replay is deprecated for newly collected data.
+:::
 
 <!-- Importing links -->
 import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
@@ -103,14 +217,17 @@ import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLink
 <StructuredLinks
     demoLinks={[
         {name: "React Stroop Demo", url: "https://revisit.dev/study/demo-react-trrack/"},
-        {name: "HTML Track Demo", url: "https://revisit.dev/study/demo-html-trrack/"}
+        {name: "HTML Trrack Demo", url: "https://revisit.dev/study/demo-html-trrack/"},
+        {name: "Svelte Trrack Demo", url: "https://revisit.dev/study/demo-svelte-trrack/"}
     ]}
     codeLinks={[
-        {name: "React Stroop Code", url: "https://github.com/revisit-studies/study/tree/main/public/demo-react-trrack"},
-        {name: "HTML Track Code", url: "https://github.com/revisit-studies/study/tree/main/public/demo-html-trrack"}
+        {name: "React Stroop Code", url: "https://github.com/revisit-studies/study/tree/dev/src/public/demo-react-trrack"},
+        {name: "HTML Trrack Code", url: "https://github.com/revisit-studies/study/tree/dev/public/demo-html-trrack"},
+        {name: "Svelte Trrack Code", url: "https://github.com/revisit-studies/study/tree/dev/public/demo-svelte-trrack"}
     ]}
     referenceLinks={[
         {name: "Trrack", url: "https://apps.vdl.sci.utah.edu/trrack"},
-        {name: "React Stimulus", url: "../react-stimulus"}
+        {name: "React Stimulus", url: "../react-stimulus"},
+        {name: "HTML Stimulus", url: "../html-stimulus"}
     ]}
 />

--- a/docs/designing-studies/react-stimulus.md
+++ b/docs/designing-studies/react-stimulus.md
@@ -280,10 +280,14 @@ Below is a minimal config with two Stroop trials. Each trial passes `displayText
 
 ### Adding provenance tracking
 
-To record user interactions and enable replay, you can add provenance tracking with Trrack. This involves:
+To record user interactions and enable replay, use the managed `useRevisitTrrack` hook. This involves:
+
 - Creating a Trrack registry and actions for state changes
-- Passing `provenanceGraph` in `setAnswer` so reVISit stores the provenance
-- Using `provenanceState` to restore the textbox during replay
+- Passing the registry and initial state to `useRevisitTrrack`
+- Continuing to use `setAnswer` for answers without attaching a provenance graph
+- Using `provenanceState` to render the restored state during replay
+
+The hook automatically captures the initial state, apply, undo, redo, and other traversals, then cleans up its subscription when the stimulus unmounts. Passing `provenanceGraph` to `setAnswer` is deprecated, although it remains backward-compatible for historical studies.
 
 For a full walkthrough, see the [Provenance Tracking](provenance-tracking.md) tutorial.
 


### PR DESCRIPTION
## Summary

- document `useRevisitTrrack` for React stimuli and `Revisit.createTrrack` for website/iframe stimuli
- explain automatic initial-state and traversal capture, replay hydration, and lifecycle cleanup
- add before/after migrations from `initializeTrrack` plus `setAnswer({ provenanceGraph })` and `Revisit.postProvenance`
- mark manual provenance reporting and graph-only replay as deprecated but backward-compatible for historical studies
- update the React and HTML stimulus tutorials with the managed workflow

Implementation source of truth: `revisit-studies/study` branch `codex/issue-659-managed-trrack`.

## Validation

- `yarn typecheck`
- `yarn build`
- `yarn checkLinks` (all links introduced here pass; the command still reports two pre-existing external 404s in `blog/2026-04-30-llm-in-revisit.md`)

Generated TypeDoc remains release-managed from the app repository, per this docs repository's contribution guidance.
